### PR TITLE
[HTTP] Introduce user authentication using secure encoded passwords

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,10 @@
                 <sonar.host.url>https://sonarcloud.io</sonar.host.url>
 	</properties>
 	<dependencies>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-security</artifactId>
+                </dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>

--- a/src/main/java/com/flightman/flightmanapi/WebSecurityConfig.java
+++ b/src/main/java/com/flightman/flightmanapi/WebSecurityConfig.java
@@ -1,0 +1,56 @@
+package com.flightman.flightmanapi;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@Configuration
+@EnableWebSecurity
+public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
+
+    @Override
+    protected void configure(AuthenticationManagerBuilder auth) throws Exception {
+        String encoded = "$2a$10$crpxHWNDARalaJuJdwxKbOrLmIozjWTMiM3M.zRHfSt02ELd/mxDe";
+        auth.inMemoryAuthentication()
+            .passwordEncoder(new BCryptPasswordEncoder())
+                .withUser("srishti")
+                .password(encoded)
+                .roles("USER")
+            .and()
+                .withUser("ajay")
+                .password(encoded)
+                .roles("USER")
+            .and()
+                .withUser("abhilash")
+                .password(encoded)
+                .roles("USER")
+            .and()
+                .withUser("miloni")
+                .password(encoded)
+                .roles("USER")
+            .and()
+                .withUser("otito")
+                .password(encoded)
+                .roles("USER")
+            .and()
+                .withUser("peter")
+                .password(encoded)
+                .roles("USER")
+            .and()
+                .withUser("professor_kaiser")
+                .password(encoded)
+                .roles("USER")
+            ;
+    }
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http.authorizeRequests()
+            .anyRequest().authenticated()
+            .and()
+            .httpBasic();
+    }
+}


### PR DESCRIPTION
Introduced user HTTP authentication to ensure that the server is only accessed by authenticated users. The passwords of users are encoded before storing in the server, instead of storing their actual values, to ensure proper security protocols.

Signed-off-by: Srishti Srivastava <ss6624@columbia.edu>